### PR TITLE
[BUGFIX] Increase index used for constants resolving in rootPaths

### DIFF
--- a/Classes/Aggregate/ContentRenderingAggregate.php
+++ b/Classes/Aggregate/ContentRenderingAggregate.php
@@ -142,11 +142,11 @@ EOS
 tt_content.mask_{$key} = FLUIDTEMPLATE
 tt_content.mask_{$key} {
     layoutRootPaths.0 = {$layoutsPath}
-    layoutRootPaths.1 = {\$plugin.tx_mask.view.layoutRootPath}
+    layoutRootPaths.10 = {\$plugin.tx_mask.view.layoutRootPath}
     partialRootPaths.0 = {$partialPath}
-    partialRootPaths.1 = {\$plugin.tx_mask.view.partialRootPath}
+    partialRootPaths.10 = {\$plugin.tx_mask.view.partialRootPath}
     templateRootPaths.0 = {$templatesPath}
-    templateRootPaths.1 = {\$plugin.tx_mask.view.templateRootPath}
+    templateRootPaths.10 = {\$plugin.tx_mask.view.templateRootPath}
     templateName = {$templateName}
 
 EOS


### PR DESCRIPTION
Sometimes it is necessary to define additional paths to look for Fluid
files. Therefore the index for the constants is increased to .10.