### PR TITLE
Remove backend rootpath

### DIFF
--- a/Classes/Aggregate/AbstractAggregate.php
+++ b/Classes/Aggregate/AbstractAggregate.php
@@ -42,6 +42,21 @@ abstract class AbstractAggregate
     ];
 
     /**
+     * @var string
+     */
+    protected $languageFilePath = 'Resources/Private/Language/';
+
+    /**
+     * @var string
+     */
+    protected $pageTSConfigFilePath = 'Configuration/PageTSconfig/';
+
+    /**
+     * @var string
+     */
+    protected $typoScriptFilePath = 'Configuration/TypoScript/';
+
+    /**
      * @param array $maskConfiguration
      */
     public function __construct(array $maskConfiguration)

--- a/Classes/Aggregate/ContentRenderingAggregate.php
+++ b/Classes/Aggregate/ContentRenderingAggregate.php
@@ -64,11 +64,6 @@ class ContentRenderingAggregate extends AbstractOverridesAggregate implements Pl
     protected $partialPath = 'Partials/';
 
     /**
-     * @var string
-     */
-    protected $typoScriptFilePath = 'Configuration/TypoScript/';
-
-    /**
      * @param array $maskConfiguration
      * @param HtmlCodeGenerator $htmlCodeGenerator
      */

--- a/Classes/Aggregate/InlineContentColPosAggregate.php
+++ b/Classes/Aggregate/InlineContentColPosAggregate.php
@@ -36,11 +36,6 @@ class InlineContentColPosAggregate extends AbstractInlineContentAggregate implem
     protected $languageFileIdentifier = 'locallang_db.xlf';
 
     /**
-     * @var string
-     */
-    protected $languageFilePath = 'Resources/Private/Language/';
-
-    /**
      * Adds dataProvider for inline content colPos name
      */
     protected function process()

--- a/Classes/Aggregate/NewContentElementWizardAggregate.php
+++ b/Classes/Aggregate/NewContentElementWizardAggregate.php
@@ -39,17 +39,7 @@ class NewContentElementWizardAggregate extends AbstractAggregate implements Lang
     /**
      * @var string
      */
-    protected $languageFilePath = 'Resources/Private/Language/';
-
-    /**
-     * @var string
-     */
     protected $pageTSConfigFileIdentifier = 'NewContentElementWizard.ts';
-
-    /**
-     * @var string
-     */
-    protected $pageTSConfigFilePath = 'Configuration/PageTSconfig/';
 
     /**
      * Adds content elements to the newContentElementWizard


### PR DESCRIPTION
Provide paths to backend preview templates in Page TSconfig. This
allows to overwrite the configuration and makes backend previews more
flexible.