### PR TITLE
[BUGFIX] Change default extension key

### DIFF
--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -71,7 +71,7 @@ class ExportController extends ActionController
     /**
      * @var string
      */
-    protected $defaultExtensionName = 'mask_export';
+    protected $defaultExtensionName = 'my_mask_export';
 
     /**
      * @var array


### PR DESCRIPTION
With the possibility to write the export to the file system, the default
extension key needs to be changed. Otherwise mask_export will overwrite
itself.

Resolves: #110 